### PR TITLE
feat: 添加MCP部分接口实现

### DIFF
--- a/console/workspaces.go
+++ b/console/workspaces.go
@@ -361,3 +361,93 @@ func (c *Client) DeleteToolApiProvider(ctx context.Context, provider string) (*m
 	err := c.baseClient.DoJSON(ctx, req, &resp)
 	return &resp, err
 }
+
+// CreateMCPProvider 创建 MCP Provider
+func (c *Client) CreateMCPProvider(ctx context.Context, serverURL, name string, icon interface{}, iconType, iconBackground, serverIdentifier string) (*models.ToolProviderEntity, error) {
+	req := &client.Request{
+		Method: "POST",
+		Path:   "/workspaces/current/tool-provider/mcp",
+		Body: map[string]interface{}{
+			"server_url":        serverURL,
+			"name":              name,
+			"icon":              icon,
+			"icon_type":         iconType,
+			"icon_background":   iconBackground,
+			"server_identifier": serverIdentifier,
+		},
+	}
+	var resp models.ToolProviderEntity
+	err := c.baseClient.DoJSON(ctx, req, &resp)
+	return &resp, err
+}
+
+// UpdateMCPProvider 更新 MCP Provider
+func (c *Client) UpdateMCPProvider(ctx context.Context, providerID, serverURL, name string, icon any, iconType, iconBackground, serverIdentifier string) (*models.ToolProviderEntity, error) {
+	req := &client.Request{
+		Method: "PUT",
+		Path:   "/workspaces/current/tool-provider/mcp",
+		Body: map[string]interface{}{
+			"provider_id":       providerID,
+			"server_url":        serverURL,
+			"name":              name,
+			"icon":              icon,
+			"icon_type":         iconType,
+			"icon_background":   iconBackground,
+			"server_identifier": serverIdentifier,
+		},
+	}
+	var resp models.ToolProviderEntity
+	err := c.baseClient.DoJSON(ctx, req, &resp)
+	return &resp, err
+}
+
+// DeleteMCPProvider 删除 MCP Provider
+func (c *Client) DeleteMCPProvider(ctx context.Context, providerID string) (map[string]interface{}, error) {
+	req := &client.Request{
+		Method: "DELETE",
+		Path:   "/workspaces/current/tool-provider/mcp",
+		Body: map[string]interface{}{
+			"provider_id": providerID,
+		},
+	}
+	var resp map[string]interface{}
+	err := c.baseClient.DoJSON(ctx, req, &resp)
+	return resp, err
+}
+
+// GetMCPProviderDetail 获取 MCP Provider 详情
+func (c *Client) GetMCPProviderDetail(ctx context.Context, providerID string) (*models.ToolProviderEntity, error) {
+	req := &client.Request{
+		Method: "GET",
+		Path:   "/workspaces/current/tool-provider/mcp/tools/" + providerID,
+	}
+	var resp models.ToolProviderEntity
+	err := c.baseClient.DoJSON(ctx, req, &resp)
+	return &resp, err
+}
+
+// UpdateMCPProviderTools 拉取 MCP Provider 工具列表
+func (c *Client) UpdateMCPProviderTools(ctx context.Context, providerID string) (*models.OperationResponse, error) {
+	req := &client.Request{
+		Method: "GET",
+		Path:   "/workspaces/current/tool-provider/mcp/update/" + providerID,
+	}
+	var resp models.OperationResponse
+	err := c.baseClient.DoJSON(ctx, req, &resp)
+	return &resp, err
+}
+
+// AuthMCPProvider MCP Provider 认证
+func (c *Client) AuthMCPProvider(ctx context.Context, providerID, authorizationCode string) (*models.OperationResponse, error) {
+	req := &client.Request{
+		Method: "POST",
+		Path:   "/workspaces/current/tool-provider/mcp/auth",
+		Body: map[string]interface{}{
+			"provider_id":        providerID,
+			"authorization_code": authorizationCode,
+		},
+	}
+	var resp models.OperationResponse
+	err := c.baseClient.DoJSON(ctx, req, &resp)
+	return &resp, err
+}

--- a/models/console.go
+++ b/models/console.go
@@ -621,7 +621,7 @@ type ToolProviderEntity struct {
 	Author                 string                 `json:"author"`
 	Name                   string                 `json:"name"`
 	Description            map[string]string      `json:"description"`
-	Icon                   string                 `json:"icon"`
+	Icon                   interface{}            `json:"icon"`
 	IconDark               *string                `json:"icon_dark"`
 	Label                  map[string]string      `json:"label"`
 	Type                   string                 `json:"type"`

--- a/test/console_test/console_mcp_test.go
+++ b/test/console_test/console_mcp_test.go
@@ -1,0 +1,82 @@
+package console_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var mcp_use_real_url = true
+
+// mock server，路径和返回内容严格参考workspaces.go接口实现
+func SetupMCPMockServer() *httptest.Server {
+	handler := http.NewServeMux()
+
+	return httptest.NewServer(handler)
+}
+
+func TestCreateMCPProvider(t *testing.T) {
+	mockServer := SetupMCPMockServer()
+	defer mockServer.Close()
+
+	client := TestNewClientWithBaseURL(mockServer.URL, mcp_use_real_url)
+
+	resp, err := client.CreateMCPProvider(context.Background(), "http://host.docker.internal:8909/mcp", "mcp", "🧿", "emoji", "#EFF1F5", "mcp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("resp: %+v", resp)
+}
+
+func TestUpdateMCPProvider(t *testing.T) {
+	mockServer := SetupMCPMockServer()
+	defer mockServer.Close()
+
+	client := TestNewClientWithBaseURL(mockServer.URL, mcp_use_real_url)
+
+	resp, err := client.UpdateMCPProvider(context.Background(), "b17ecd18-274c-49ec-8d3d-3122e2ecdf82", "http://host.docker.internal:8909/mcp", "mcp1", "🧿", "emoji", "#EFF1F5", "mcp1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("resp: %+v", resp)
+}
+
+func TestGetMCPProviderDetail(t *testing.T) {
+	mockServer := SetupMCPMockServer()
+	defer mockServer.Close()
+
+	client := TestNewClientWithBaseURL(mockServer.URL, mcp_use_real_url)
+
+	resp, err := client.GetMCPProviderDetail(context.Background(), "b17ecd18-274c-49ec-8d3d-3122e2ecdf82")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("resp: %+v", resp)
+}
+
+func TestAuthMCPProvider(t *testing.T) {
+	mockServer := SetupMCPMockServer()
+	defer mockServer.Close()
+
+	client := TestNewClientWithBaseURL(mockServer.URL, mcp_use_real_url)
+
+	resp, err := client.AuthMCPProvider(context.Background(), "13e3a8f0-47cd-4284-a503-4154086dc05a", "123456")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("resp: %+v", resp)
+}
+
+func TestDeleteMCPProvider(t *testing.T) {
+	mockServer := SetupMCPMockServer()
+	defer mockServer.Close()
+
+	client := TestNewClientWithBaseURL(mockServer.URL, mcp_use_real_url)
+
+	resp, err := client.DeleteMCPProvider(context.Background(), "13e3a8f0-47cd-4284-a503-4154086dc05a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("resp: %+v", resp)
+}


### PR DESCRIPTION
添加一下六个接口
☑ ‍POST /console/api//workspaces/current/tool-provider/mcp -创建MCP
☑ POST /console/api/workspaces/current/tool-provider/mcp- 创建 MCP
☑ PUT /console/api/workspaces/current/tool-provider/mcp- 更新 MCP
☑ DELETE /console/api/workspaces/current/tool-provider/mcp - 删除 MCP
☑ GET /console/api/workspaces/current/tool-provider/mcp/tools/{provider_id}` - 获取 MCP详情
☑ GET /console/api/workspaces/current/tool-provider/mcp/update/{provider_id}` - 拉取 MCP工具列表
☑ POST /console/api/workspaces/current/tool-provider/mcp/auth - MCP认证